### PR TITLE
Fixing Incorrect linkObject's href schema definition for mediatype hal

### DIFF
--- a/src/mediatypes/hal.json
+++ b/src/mediatypes/hal.json
@@ -29,7 +29,7 @@
       "properties": {
         "name": { "$ref": "http://hyperschema.org/core/base#/definitions/name" },
         "href": {
-          "oneOf": [
+          "anyOf": [
             { "$ref": "http://hyperschema.org/core/link#/definitions/href" },
             { "$ref": "http://hyperschema.org/core/link#/definitions/hrefTemplated" }
           ]


### PR DESCRIPTION
Following benfalk's suggestion (Issue #4) ...