### PR TITLE
Fix the 'value' definition for UBER. to allow other types.

### DIFF
--- a/src/mediatypes/uber.json
+++ b/src/mediatypes/uber.json
@@ -33,7 +33,14 @@
         "model": { "$ref": "http://hyperschema.org/core/link#/definitions/queryStringURITemplate" },
         "sending": { "$ref": "http://hyperschema.org/core/base#/definitions/mediaTypes" },
         "accepting": { "$ref": "http://hyperschema.org/core/base#/definitions/mediaTypes" },
-        "value": { "type": "string" },
+        "value": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "boolean" },
+            { "type": "null" }
+          ]
+        },
         "data": { "$ref": "#/definitions/dataArray" }
       }
     },


### PR DESCRIPTION
See https://rawgit.com/uber-hypermedia/specification/master/uber-hypermedia.html#_the_span_class_monospaced_lt_data_gt_span_element for the definition of `value`.